### PR TITLE
Update weekly_dev_to_main_pr.yml

### DIFF
--- a/.github/workflows/weekly_dev_to_main_pr.yml
+++ b/.github/workflows/weekly_dev_to_main_pr.yml
@@ -16,17 +16,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch branches
+        run: |
+          git fetch origin main
+          git fetch origin dev
 
       - name: Close previous auto-generated PRs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Find and close PRs from dev to main created by this action
+          # Find open PRs from dev to main with our specific title
           gh pr list \
             --base main \
             --head dev \
             --state open \
-            --label "automated-weekly-pr" \
+            --search "Weekly: Merge dev into main in:title" \
             --json number \
             --jq '.[].number' | while read pr_number; do
               if [ -n "$pr_number" ]; then
@@ -50,8 +57,7 @@ jobs:
           Please review the changes and merge when ready.
 
           ---
-          *This PR was automatically created by GitHub Actions*" \
-              --label "automated-weekly-pr" || echo "PR might already exist"
+          *This PR was automatically created by GitHub Actions*" || echo "PR might already exist"
           else
             echo "No changes between dev and main, skipping PR creation"
           fi

--- a/.github/workflows/weekly_dev_to_main_pr.yml
+++ b/.github/workflows/weekly_dev_to_main_pr.yml
@@ -16,19 +16,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Close previous auto-generated PRs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Find and close PRs from dev to main created by github-actions bot
+          # Find and close PRs from dev to main created by this action
           gh pr list \
             --base main \
             --head dev \
-            --author "github-actions[bot]" \
             --state open \
+            --label "automated-weekly-pr" \
             --json number \
             --jq '.[].number' | while read pr_number; do
               if [ -n "$pr_number" ]; then
@@ -38,17 +36,22 @@ jobs:
             done
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ github.token }}
-          branch: dev
-          base: main
-          title: 'Weekly: Merge dev into main'
-          body: |
-            This is an automated weekly PR to merge changes from `dev` into `main`.
-            
-            Please review the changes and merge when ready.
-            
-            ---
-            *This PR was automatically created by GitHub Actions*
-          labels: automated
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Check if dev and main are different
+          if ! git diff --quiet origin/main...origin/dev; then
+            gh pr create \
+              --base main \
+              --head dev \
+              --title "Weekly: Merge dev into main" \
+              --body "This is an automated weekly PR to merge changes from \`dev\` into \`main\`.
+
+          Please review the changes and merge when ready.
+
+          ---
+          *This PR was automatically created by GitHub Actions*" \
+              --label "automated-weekly-pr" || echo "PR might already exist"
+          else
+            echo "No changes between dev and main, skipping PR creation"
+          fi


### PR DESCRIPTION
Follow-up to https://github.com/FRC2713/Robot2025/pull/56

The `weekly_dev_to_main_pr.yml` action is meant to consistently merge changes from the `dev` branch to the `main` branch.
- It opens a weekly automated PR
- If there's a PR already open from a previous week, it will close that to avoid accumulating these
- If there are no changes between `dev` and `main`, it won't open a PR

Now uses GitHub CLI (`gh pr create`) to create the automated PR.